### PR TITLE
Change useEffect to pre-rendeding getStatisProps and getStaticPaths

### DIFF
--- a/pages/index.js
+++ b/pages/index.js
@@ -1,17 +1,11 @@
-import React, { useState, useEffect } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import { Container, Grid } from '@material-ui/core';
 
+import { getAll } from 'database/db';
 import ProductList from 'components/ProductList';
 
-const HomePage = () => {
-  const [productList, setProductList] = useState([]);
-
-  useEffect(() => {
-    fetch('/api/shirt')
-      .then(response => response.json())
-      .then(data => setProductList(data?.items));
-  }, []);
-
+const HomePage = ({ productList }) => {
   return (
     <Container maxWidth="xl">
       <Grid container>
@@ -19,6 +13,16 @@ const HomePage = () => {
       </Grid>
     </Container>
   );
+};
+
+export function getStaticProps() {
+  const { items } = getAll();
+
+  return { props: { productList: items } };
+}
+
+HomePage.propTypes = {
+  productList: PropTypes.array,
 };
 
 export default HomePage;

--- a/pages/product/[id].js
+++ b/pages/product/[id].js
@@ -1,11 +1,11 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState } from 'react';
+import PropTypes from 'prop-types';
 import Image from 'next/image';
-import { useRouter } from 'next/router';
 import { Grid, Container, Typography, Button } from '@material-ui/core';
 import { styled, makeStyles, useTheme } from '@material-ui/core/styles';
 import clsx from 'clsx';
-import fetch from 'isomorphic-unfetch';
 
+import { getAll, getById } from 'database/db';
 import { sizeList } from 'utils/product';
 
 const useStyles = makeStyles(theme => ({
@@ -55,18 +55,10 @@ const ProductImages = styled('div')({
   width: '100%',
 });
 
-const ProductPage = () => {
-  const { query } = useRouter();
+const ProductPage = ({ product }) => {
   const theme = useTheme();
   const classes = useStyles(theme);
-  const [product, setProduct] = useState(null);
   const [sizeSelected, setSizeSelected] = useState(null);
-
-  useEffect(() => {
-    fetch(`/api/shirt/${query.id}`)
-      .then(response => response.json())
-      .then(({ item }) => setProduct(item));
-  }, []);
 
   return (
     <Container maxWidth="xl">
@@ -140,6 +132,23 @@ const ProductPage = () => {
       </Grid>
     </Container>
   );
+};
+
+export const getStaticProps = async ({ params: { id } }) => {
+  const product = getById(id);
+
+  return { props: { product } };
+};
+
+export const getStaticPaths = async () => {
+  const { items } = getAll();
+
+  const paths = items.map(item => ({ params: { id: item.id } }));
+  return { paths, fallback: false };
+};
+
+ProductPage.propTypes = {
+  product: PropTypes.object,
 };
 
 export default ProductPage;


### PR DESCRIPTION
#### What does this PR do?
- Change useEffect to pre-rendeding getStatisProps and getStaticPaths.

#### Any background context you want to provide?
Before this change, it was requesting the data using a fetch API.

#### Notes
I'm using getStaticProps and getStaticPaths calling the Next.JS API directly.
